### PR TITLE
Merge to update parent POM version to take advantage of new Maven Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@ Go through this file line-by-line and replace the template values with your own.
     parent at https://github.com/NASA-PDS/pdsen-maven-parent
     -->
     <parent>
-        <groupId>gov.nasa</groupId>
-        <artifactId>pds</artifactId>
+        <groupId>gov.nasa.pds</groupId>
+        <artifactId>parent</artifactId>
         <version>1.19.0</version>
     </parent>
   


### PR DESCRIPTION
## 🗒️ Summary

Merge this to update the version of the parent POM. The parent POM in 0.19.0 will be using the newer Maven Central Portal, which is now preferred as the [Maven OSSRH is reaching end-of-life](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration) on 2025-06-30.

Please note that the [the parent POM's pull request](https://github.com/NASA-PDS/pdsen-maven-parent/pull/66) needs to be merged and the parent package v0.19.0 published for this to take effect—and after the [namespace is migrated to the Central Portal](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration).


## ⚙️ Test Data and/or Report

Not possible to test without actually using this repository as a template and attempting to do a  SNAPSHOT or full release of the project.


## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/129
- #67 
